### PR TITLE
Fix homed config

### DIFF
--- a/modules/workstation/homed.nix
+++ b/modules/workstation/homed.nix
@@ -3,7 +3,7 @@
     services.homed.enable = true;
 
     age.secrets."497a_homed" = {
-      file = ../../secrets + "/497a_homed.age";
+      file = ../../secrets/497a_homed.age;
       path = "/var/lib/systemd/home/497a.public";
     };
   };


### PR DESCRIPTION
Moves the age config into `config`.